### PR TITLE
Fixed the border radius bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,6 +39,7 @@ const main = async () => {
         borderColor: "rgb(255, 99, 132)",
         data: daysData,
         borderRadius: 4,
+        borderSkipped: false,
       },
     ],
   };


### PR DESCRIPTION
The border radius was not rounded at the bottom. You can fix this by adding the ```borderSkipped``` property to the ```dataSets``` object. See this example https://www.chartjs.org/docs/3.4.1/samples/bar/border-radius.html